### PR TITLE
Fix encoding error

### DIFF
--- a/bluelamp.py
+++ b/bluelamp.py
@@ -93,7 +93,7 @@ with lock:
             bluectl.sendline('paired-devices')
             retValue = -1
             try:
-                retValue = bluectl.expect(['Device %s Hue Lamp' % (bulb)], timeout=5)
+                retValue = bluectl.expect(['Device %s ' % (bulb)], timeout=5)
             except:
                 pass
             if retValue != 0:

--- a/bluelamp.py
+++ b/bluelamp.py
@@ -81,7 +81,7 @@ with lock:
     while rounds >= 0:
         rounds = rounds - 1
         try:
-            bluectl = pexpect.spawn('bluetoothctl')
+            bluectl = pexpect.spawn('bluetoothctl', encoding='utf-8')
             if args.verbose:
                 bluectl.logfile = sys.stdout
             bluectl.sendline('power off')
@@ -117,7 +117,7 @@ Hue lamp doesn't seem to be paired.
                 exit(1)
             
             # Run gatttool interactively.
-            gatt = pexpect.spawn('gatttool -t random -I -b %s' % bulb)
+            gatt = pexpect.spawn('gatttool -t random -I -b %s' % bulb, encoding='utf-8')
             if args.verbose:
                 gatt.logfile = sys.stdout
             


### PR DESCRIPTION
Running bluelamp.py yields:

```
[bluetooth]# Traceback (most recent call last):
  File "bluelamp.py", line 128, in <module>
    gatt.sendline('connect')
  File "/home/ubuntu/code/hue/env/lib/python3.8/site-packages/pexpect/pty_spawn.py", line 578, in sendline
    return self.send(s + self.linesep)
  File "/home/ubuntu/code/hue/env/lib/python3.8/site-packages/pexpect/pty_spawn.py", line 566, in send
    self._log(s, 'send')
  File "/home/ubuntu/code/hue/env/lib/python3.8/site-packages/pexpect/spawnbase.py", line 129, in _log
    self.logfile.write(s)
TypeError: write() argument must be str, not bytes
```

This is fixed by specifying the encoding in the call to spawn.

Moreover (sorry for exploiting the same PR) the script now doesn't depend on the factory name of the lamp, which may have been changed by the user.